### PR TITLE
Fix/locations

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -23,12 +23,6 @@ class Location < ActiveRecord::Base
     ::PushService.new().pushUpdates(self)
   end
   
-	after_initialize :init
-
-	def init
-		self.deleted = false
-	end
-
 	def self.values
 		::Location.all.map do |location|
 			[location.name, location.id]

--- a/db/migrate/20180711203745_add_default_value_to_deleted_in_locations.rb
+++ b/db/migrate/20180711203745_add_default_value_to_deleted_in_locations.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToDeletedInLocations < ActiveRecord::Migration
+  def change
+  	change_column :locations, :deleted, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
WHAT?
BUG: The locations endpoints always returns `false` for the deleted flag.

This PR fixes the mentioned. Removing the `after_initialize` callback and adding a default value false to the database schema. 